### PR TITLE
Style web page elements and dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,3 +218,14 @@ body.dark-mode .modal-content {
 .close:hover {
   color: #444;
 }
+
+body.dark-mode #configuracao label {
+  color: #0d3b66 !important;
+}
+
+body.dark-mode #configuracao input,
+body.dark-mode #configuracao select {
+  background-color: #555 !important;
+  color: #eee !important;
+  border-color: #888 !important;
+}


### PR DESCRIPTION
Add missing dark mode styles for `#configuracao` labels, inputs, and selects to `style.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3a6e1ac-a552-432c-88ab-c47c72f14365">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3a6e1ac-a552-432c-88ab-c47c72f14365">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

